### PR TITLE
Reducing forecast periods for hourly forecast to 24

### DIFF
--- a/app/src/main/java/com/supermanzer/weatherapp/HourlyForecastFragment.kt
+++ b/app/src/main/java/com/supermanzer/weatherapp/HourlyForecastFragment.kt
@@ -45,7 +45,8 @@ class HourlyForecastFragment : Fragment() {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.hourlyForecastPeriods.observe(viewLifecycleOwner) { items ->
                     Log.d(TAG, "Hourly forecast periods: $items")
-                    binding.hourlyForecastList.adapter = HourlyForecastListAdapter(items)
+                    val forecastPeriods = items.take(24)
+                    binding.hourlyForecastList.adapter = HourlyForecastListAdapter(forecastPeriods)
                 }
             }
         }


### PR DESCRIPTION
This prevents the hourly side scroll in the layout fragment from extending the side scroll too far
